### PR TITLE
Fixes Issue #2. Now works under OS X *and* Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Open your github or bitbucket project page from your terminal
 You have that `.sh` file but you can use it as a function on your, let's say, `.bash_profile`.
 
 ```bash
+function _opengit_open()
+{
+  local open_cmd='huh?'
+  if [ -n `echo $MACHTYPE | grep darwin` ]; then
+    open_cmd='open'
+  else
+    open_cmd='xdg-open'
+  fi
+  $open_cmd $1
+}
+
 function opengit() {
   if [ -d .git ]; then
     if [ -z "$(git remote -v)" ]; then
@@ -27,7 +38,7 @@ function opengit() {
       else
         url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1)/tree/${1}"
       fi
-      xdg-open $url
+      _opengit_open $url
     fi
   else
     echo "Crap, ain't no git repo"
@@ -42,7 +53,7 @@ and `. ~/.bash_profile` to load the change. Now you can `opengit` on your termin
 You can
 
     $ opengit
-    
+
 or
 
     $ opengit remote_branch

--- a/opengit.sh
+++ b/opengit.sh
@@ -1,3 +1,14 @@
+function _opengit_open()
+{
+  local open_cmd='huh?'
+  if [ -n `echo $MACHTYPE | grep darwin` ]; then
+    open_cmd='open'
+  else
+    open_cmd='xdg-open'
+  fi
+  $open_cmd $1
+}
+
 if [ -d .git ]; then
   if [ -z "$(git remote -v)" ]; then
     echo "Hum....there are no remotes here"
@@ -18,7 +29,7 @@ if [ -d .git ]; then
     else
       url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1)/tree/${1}"
     fi
-    xdg-open $url
+    _opengit_open $url
   fi
 else
   echo "Crap, ain't no git repo"


### PR DESCRIPTION
At the cost of creating a new, "internal" function (`_opengit_open`), tests the `$MACHTYPE` environment variable to determine if running under OS X. If so, uses the command `open` to open the Github URL; otherwise uses the (previously hard-coded) [`xdg-open`](http://linux.die.net/man/1/xdg-open) command.

Tested under OS X (duh; 10.9) as well as Linux Mint 15.
