### PR TITLE
uniq those lines

### DIFF
--- a/opengit.sh
+++ b/opengit.sh
@@ -32,9 +32,9 @@ if [ -d .git ]; then
     fi
 
     if [ -z "$1" ];then
-      url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1)/tree/$(current_branch)"
+      url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1 | uniq)/tree/$(current_branch)"
     else
-      url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1)/tree/${1}"
+      url="$where$(echo $remotes | cut -d" " -f1 | cut -d"." -f1 | uniq)/tree/${1}"
     fi
     _opengit_open $url
   fi


### PR DESCRIPTION
Sometimes the `$remotes` variable has the repo twice across two lines - this takes care of that.

Fix works on linux (tested Ubuntu) and Mac (tested 10.9).

Closes https://github.com/gerep/opengit/issues/4
